### PR TITLE
GeoFence - georchestra integration fix

### DIFF
--- a/src/geoserver/security/src/main/java/it/geosolutions/geofence/GeofenceAccessManager.java
+++ b/src/geoserver/security/src/main/java/it/geosolutions/geofence/GeofenceAccessManager.java
@@ -243,7 +243,11 @@ public class GeofenceAccessManager implements ResourceAccessManager, DispatcherC
                 LOGGER.log(Level.FINE, "Admin level access, returning " +
                     "full rights for layer {0}", resource.getPrefixedName());
 
-                return buildAccessLimits(resource, AccessInfo.ALLOW_ALL);
+                // georchestra fix: Being coherent with what GeoServer does:
+                //
+                // if administrator, WrapperPolicy.getLimits() should return null.
+                // (see SecureCatalogImpl.java:506,590 in GeoServer)
+                return null;
             }
 
             username = user.getName();


### PR DESCRIPTION
Without geofence, when user is member of ROLE_ADMINISTRATOR,
policy.getLimits() returns null. With Geofence activated, an object is
systematically created, making some tests fail in geoserver code, e.g.
in SecureCatalogImpl.java:590:

else if(policy.level == AccessLevel.READ_WRITE && policy.getLimits() == null)

This commit fixes #748, #884, #885, #887 and shall only affect
administrator users.
