### PR TITLE
Geoserver/Geofence - Correction bug encodage

### DIFF
--- a/src/geoserver/web-app/src/main/webapp/WEB-INF/web.xml
+++ b/src/geoserver/web-app/src/main/webapp/WEB-INF/web.xml
@@ -181,6 +181,11 @@
      reasons 
      -->
    </filter>
+   
+   <filter-mapping>
+      <filter-name>Set Character Encoding</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
 
     <filter-mapping>
       <filter-name>SessionDebugger</filter-name>
@@ -214,11 +219,6 @@
       <filter-name>Georepository alternate security filter</filter-name>
       <url-pattern>/*</url-pattern>
     </filter-mapping>-->
-    
-      <filter-mapping>
-      <filter-name>Set Character Encoding</filter-name>
-      <url-pattern>/*</url-pattern>
-    </filter-mapping>
     
     <filter-mapping>
       <filter-name>Advanced Dispatch Filter</filter-name>


### PR DESCRIPTION
Ceci corrige le bug mentionné ici :https://github.com/georchestra/georchestra/issues/903

Ce bug n'est présent que pour la compilation de GS avec GeoFence.

Solution trouvée ici : http://jira.codehaus.org/browse/GEOS-6083
